### PR TITLE
Adding file necessary for pre commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: 'cafd550'
+    hooks:
+      - id: prettier


### PR DESCRIPTION
Allows pre-commits to be done (and uses prettier as default). Does not install pre-commit nor activate it - this must be done manually via "pip install pre-commit" and then "pre-commit install"